### PR TITLE
do not cache non-capabilities wmts response

### DIFF
--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/readers/WMTSCapReader.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/readers/WMTSCapReader.java
@@ -8,12 +8,12 @@ import net.wirelabs.jmaps.map.model.wmts.Capabilities;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
-import java.io.File;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import static net.wirelabs.jmaps.map.Defaults.DEFAULT_WMTS_DESCRIPTOR_CACHE;
 
@@ -29,27 +29,48 @@ public class WMTSCapReader {
     public static Capabilities loadCapabilities(String getCapabilitiesUrl) {
 
         try {
-
             URI uri = URI.create(getCapabilitiesUrl);
             File cachedFile = Paths.get(descriptorCacheDir, uri.getHost(), uri.getPath(), "capabilities.xml").toFile();
 
             if (!cachedFile.exists()) {
                 log.info("Loading WMTS capabilities from {}", getCapabilitiesUrl);
-                URL request = new URL(getCapabilitiesUrl);
-                InputStream is = request.openConnection().getInputStream();
-                Files.createDirectories(cachedFile.toPath().getParent());
-                Files.write(cachedFile.toPath(), is.readAllBytes());
+                return parseCapabilitiesFromNetwork(getCapabilitiesUrl, cachedFile);
             } else {
                 log.info("Loading WMTS capabilities from cached file {}", cachedFile);
+                return parseCapabilitiesFromFile(cachedFile);
             }
-            return parseCapabilitiesFile(cachedFile);
         } catch (Exception e) {
-            throw new IllegalStateException("Could not parse Capablities.xml", e);
+            throw new IllegalStateException("Could not parse Capabilities.xml", e);
         }
 
     }
 
-    private static Capabilities parseCapabilitiesFile(File capabilitiesFile) throws JAXBException {
+    private static Capabilities parseCapabilitiesFromNetwork(String url, File cachedFile) throws JAXBException, IOException {
+
+        URL request = new URL(url);
+        InputStream networkInputStream = request.openConnection().getInputStream();
+
+        File tempFile = createTempFile(networkInputStream);
+        Capabilities caps = parseCapabilitiesFromFile(tempFile);
+
+        cacheFile(cachedFile, tempFile);
+
+        return caps;
+    }
+
+    private static void cacheFile(File cachedFile, File tempFile) throws IOException {
+        Files.createDirectories(cachedFile.toPath().getParent());
+        Files.move(tempFile.toPath(), cachedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+
+    private static File createTempFile(InputStream is) throws IOException {
+        File tempFile = File.createTempFile( "capabilities", ".xml" );
+        Files.copy(is,tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return tempFile;
+    }
+
+    private static Capabilities parseCapabilitiesFromFile(File capabilitiesFile) throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(Capabilities.class);
         Unmarshaller jaxb = context.createUnmarshaller();
         return (Capabilities) jaxb.unmarshal(capabilitiesFile);

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/readers/WMTSCapReaderTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/readers/WMTSCapReaderTest.java
@@ -19,6 +19,7 @@ class WMTSCapReaderTest {
 
     private static final File TEST_CAPABILITIES_XML_FILE = new File("src/test/resources/wmts/capabilities.xml");
     private static final File EXPECTED_CACHED_FILE = new File(TEST_CACHE_ROOT,"localhost/wmts/capabilities.xml");
+    private static final File NON_CAPABILITIES_FILE = new File("src/test/resources/wmts/non-capabilities.xml");
 
     @BeforeEach
     void deleteCacheFile() throws IOException {
@@ -48,7 +49,7 @@ class WMTSCapReaderTest {
 
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> WMTSCapReader.loadCapabilities("nonexisting"))
-                .withMessageContaining("Could not parse Capablities.xml");
+                .withMessageContaining("Could not parse Capabilities.xml");
     }
 
     @Test
@@ -58,6 +59,18 @@ class WMTSCapReaderTest {
         String testUrl = "http://localhost/wmts";
         Capabilities capabilities = WMTSCapReader.loadCapabilities(testUrl);
         assertFileIsCreatedAndHasCorrectContent(capabilities);
+    }
+
+    @Test
+    void shouldNotLoadAndCacheNonXMLFileFromNetwork() throws Exception {
+        TestHttpServer server = new TestHttpServer(NON_CAPABILITIES_FILE);
+        String testUrl = "http://localhost:" + server.getPort() + "/wmts";
+
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> WMTSCapReader.loadCapabilities(testUrl))
+                .withMessageContaining("Could not parse Capabilities.xml");
+
+        assertThat(EXPECTED_CACHED_FILE).doesNotExist();
+
     }
 
     private void assertFileIsCreatedAndHasCorrectContent(Capabilities capabilities) throws IOException {

--- a/jmaps-viewer/src/test/resources/wmts/non-capabilities.xml
+++ b/jmaps-viewer/src/test/resources/wmts/non-capabilities.xml
@@ -1,0 +1,3 @@
+<html>
+    <p>Service unavailable</p>
+</html>


### PR DESCRIPTION
Do not cache capabilities file that is not parsable. (e.g some services put the html into capabilities.xml when service is unavailable)
That would lead to never loading capabilities again on that host, making it necessary to delete bad cached file.