### PR TITLE
check validity of secondary cache entries and redownload if exceeded

### DIFF
--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/Defaults.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/Defaults.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import java.awt.Color;
 import java.nio.file.Paths;
+import java.time.Duration;
 
 /**
  * Created 9/25/23 by Michał Szwaczko (mikey@wirelabs.net)
@@ -12,6 +13,7 @@ import java.nio.file.Paths;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Defaults {
 
+    public static final Duration DEFAULT_CACHE_VALIDITY_TIME = Duration.ofDays(30);
     // default cache dir base
     private static final String HOME = System.getProperty("user.home");
     private static final String DEFAULT_CACHE_DIR = Paths.get(HOME, ".jmaps-cache").toString();

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/cache/Cache.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/cache/Cache.java
@@ -1,9 +1,13 @@
 package net.wirelabs.jmaps.map.cache;
 
+import java.time.Duration;
+
 /**
  * Created 1/4/23 by Michał Szwaczko (mikey@wirelabs.net)
  */
 public interface Cache<K,V> {
     V get(K key);
     void put(K key, V value);
+    boolean keyExpired(K key);
+    void setValidityTime(Duration duration);
 }

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/TileDownloader.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/TileDownloader.java
@@ -108,12 +108,15 @@ public class TileDownloader {
         }
 
         // now check configured local cache
-        if (secondaryCacheEnabled()) {
-            Optional<BufferedImage> image = Optional.ofNullable(secondaryTileCache.get(url));
-            if (image.isPresent()) {
-                primaryTileCache.put(url, image.get());
-                return image.get();
-            }
+        if (secondaryCacheEnabled() && !secondaryTileCache.keyExpired(url)) {
+
+                Optional<BufferedImage> image = Optional.ofNullable(secondaryTileCache.get(url));
+                if (image.isPresent()) {
+                    primaryTileCache.put(url, image.get());
+                    return image.get();
+                }
+
+
         }
 
         // else submit tile for download from the web

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/cache/DirectoryBasedCacheTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/cache/DirectoryBasedCacheTest.java
@@ -9,6 +9,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 
 
 import static net.wirelabs.jmaps.TestUtils.compareImages;
@@ -77,6 +78,21 @@ class DirectoryBasedCacheTest {
     @Test
     void testGetNonExisting() {
         assertThat(cache.get("nonexisting")).isNull();
+    }
+
+    @Test
+    void shouldCheckValidity() throws InterruptedException {
+        Duration validityTime = Duration.ofSeconds(2);
+        String URL1 = "http://tile.openstreetmap.org/2/4/5.jpg";
+
+        cache.setValidityTime(validityTime);
+        cache.put(URL1, TEST_IMAGE);
+        // get quick should return image
+        assertThat(cache.keyExpired(URL1)).isFalse();
+        // now wait expiry time plus a few ms
+        Thread.sleep(validityTime.toMillis() + 100);
+        // now get should return null (will trigger redownload upstream)
+        assertThat(cache.keyExpired(URL1)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
This closes 'tile downloader should check remote source for tile updates' based on cache time.