### PR TITLE
[#68] gpx schema clash fix

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,5 @@
 1.4.4
-
+    - [example app] fixed non-loading gpx files (conflicting schema generated names)
     - [example app] updated Czech geoportal WMTS map source
     - migrated primary tile cache from google's LRU hashMap to Caffeine LFU pool.
     - [tests] ditch old testcontainers-redis from com.redis, use generic org.testcontainers

--- a/jmaps-example/pom.xml
+++ b/jmaps-example/pom.xml
@@ -85,7 +85,7 @@
                     <sourceSchemas>gpx.xsd</sourceSchemas>
                     <repackage>net.wirelabs.jmaps.example</repackage>
                     <buildSchemas>true</buildSchemas>
-                    <name>xml</name>
+                    <name>gpx</name>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/jmaps-viewer/pom.xml
+++ b/jmaps-viewer/pom.xml
@@ -171,7 +171,7 @@
                     <sourceSchemas>mapDefinition.xsd,wmts.xsd</sourceSchemas>
                     <repackage>net.wirelabs.jmaps.viewer</repackage>
                     <buildSchemas>true</buildSchemas>
-                    <name>xml</name>
+                    <name>maps</name>
                 </configuration>
 
 


### PR DESCRIPTION
Sometime, the load gpx throws at runtime, mostly on windows. 
This is caused by xmlbeans configuration name conflict, all packages are named <name>xml</name>
This PR makes unique and more descriptive names for all submodules