### PR TITLE
Host prefix alternator

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,7 @@
+1.4.6
+    - [Issue #78] added visible map crs info
+    - [Issue #7] alternating host name prefixes for slippy maps (openstreetmap et al)
+
 1.4.5
     - restored ability to disable/enable layer in multilayer maps definitions
     - added some missed edge case tests

--- a/jmaps-example/example-maps/OpenStreetMap.xml
+++ b/jmaps-example/example-maps/OpenStreetMap.xml
@@ -5,7 +5,7 @@
         <name>Open Street Map</name>
         <maxZoom>18</maxZoom>
         <type>XYZ</type>
-        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
+        <url>http://[a|b|c].tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
     <copyright>© OpenStreetMap Contributors, Creative Commons Attribution-ShareAlike 2.0</copyright>
 </map>

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/MapRenderer.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/MapRenderer.java
@@ -2,6 +2,7 @@ package net.wirelabs.jmaps.map;
 
 
 import net.wirelabs.jmaps.map.downloader.TileProvider;
+import net.wirelabs.jmaps.map.downloader.UrlSet;
 import net.wirelabs.jmaps.map.layer.Layer;
 import net.wirelabs.jmaps.map.painters.*;
 
@@ -99,8 +100,8 @@ public class MapRenderer {
 
         for (Layer layer : mapViewer.getCurrentMap().getEnabledLayers()) {
 
-            String tileUrl = layer.createTileUrl(tileX, tileY, zoom + layer.getZoomOffset());
-            Optional<BufferedImage> b = Optional.ofNullable(tileProvider.getTile(tileUrl));
+            UrlSet tileUrl = layer.createTileUrl(tileX, tileY, zoom + layer.getZoomOffset());
+            Optional<BufferedImage> b = Optional.ofNullable(tileProvider.getTile(tileUrl.downloadUrl(), tileUrl.cacheUrl()));
             if (b.isPresent()) {
                 // if layer's opacity is < 1.0 - apply layer's opacity alpha, otherwise set alpha 1.0f
                 AlphaComposite alpha = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, Math.min(layer.getOpacity(), 1.0f));

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/cache/db/DBCache.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/cache/db/DBCache.java
@@ -19,10 +19,8 @@ public class DBCache extends BaseCache implements Cache<String, BufferedImage> {
 
     private static final String CREATE_TABLE_SQL = "CREATE TABLE TILECACHE (tileUrl VARCHAR(1024) PRIMARY KEY,tileImg BLOB,timeStamp BIGINT)";
     private static final String GET_TEMPLATE_SQL = "select TILEIMG from TILECACHE where TILEURL='%s'";
-    private static final String PUT_TEMPLATE_SQL = "INSERT INTO TILECACHE VALUES('%s', ?, ?)";
-    private static final String UPDATE_TEMPLATE_SQL = "UPDATE TILECACHE set TILEIMG=?,TIMESTAMP=? WHERE TILEURL='%s'";
+    private static final String PUT_TEMPLATE_SQL = "INSERT OR REPLACE INTO TILECACHE VALUES('%s', ?, ?)";
     private static final String GET_TIMESTAMP_TEMPLATE_SQL = "select TIMESTAMP from TILECACHE where TILEURL='%s'";
-    private static final String COUNT_TEMPLATE_SQL = "select count (*) from TILECACHE where TILEURL='%s'";
 
 
     public DBCache() {
@@ -84,14 +82,7 @@ public class DBCache extends BaseCache implements Cache<String, BufferedImage> {
     private void putImage(String key, BufferedImage value) {
         try {
             byte[] imgbytes = ImageUtils.imageToBytes(value);
-            String sqlCmd;
-
-            // always write entry - TileProvider decides if it's a re-load or new tile
-            if (!entryExists(key)) {
-                sqlCmd = String.format(PUT_TEMPLATE_SQL, key);
-            } else {
-                sqlCmd = String.format(UPDATE_TEMPLATE_SQL, key);
-            }
+            String sqlCmd = String.format(PUT_TEMPLATE_SQL, key);
 
             try (Connection connection = getConnection(); PreparedStatement ps = connection.prepareStatement(sqlCmd)) {
                 ps.setBytes(1, imgbytes);
@@ -135,11 +126,4 @@ public class DBCache extends BaseCache implements Cache<String, BufferedImage> {
         return 0;
     }
 
-    boolean entryExists(String key) throws SQLException {
-
-        String query = String.format(COUNT_TEMPLATE_SQL, key);
-        try (Connection connection = getConnection(); Statement stmt = connection.createStatement(); ResultSet rs = stmt.executeQuery(query)) {
-            return (rs.next() && rs.getInt(1) == 1);
-        }
-    }
 }

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/cache/files/DirectoryBasedCache.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/cache/files/DirectoryBasedCache.java
@@ -58,11 +58,7 @@ public class DirectoryBasedCache extends BaseCache implements Cache<String, Buff
     private void putImage(String key, BufferedImage b) {
         try {
             Path filePath = getLocalFile(key);
-            // create file only if it does not exist so that if the entry expires,
-            // file is not recreated  (saves time) and only image is written to this existing file
-            if (!filePath.toFile().exists()) {
-                Files.createDirectories(filePath);
-            }
+            Files.createDirectories(filePath.getParent());
             ImageIO.write(b, "png", filePath.toFile());
 
         } catch (IOException ex) {
@@ -87,7 +83,7 @@ public class DirectoryBasedCache extends BaseCache implements Cache<String, Buff
      * being the path for the place to store the file
      */
     private Path getLocalFile(String remoteUri) throws IOException {
-        return Path.of(getBaseDir().toString(),UrlUtils.urlToStringPath(remoteUri));
+        return Path.of(getBaseDir().toString(), UrlUtils.urlToStringPath(remoteUri));
     }
 
 }

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/DownloadingTileProvider.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/DownloadingTileProvider.java
@@ -62,7 +62,7 @@ public class DownloadingTileProvider implements TileProvider {
         return executorService;
     }
 
-    void download(String tileUrl) {
+    void download(String tileUrl, String cacheUrl) {
         log.debug("Getting from: {}", tileUrl);
 
         HttpRequest r = HttpRequest.newBuilder() //Request.nBuilder()
@@ -75,7 +75,7 @@ public class DownloadingTileProvider implements TileProvider {
             HttpResponse<InputStream> response = httpClient.send(r, HttpResponse.BodyHandlers.ofInputStream());
 
             if (response.statusCode() == 200) {
-                readAndCacheImage(tileUrl, response);
+                readAndCacheImage(cacheUrl, response);
             } else {
                 log.debug("Could not download {} - Http response {}", tileUrl, response.statusCode());
             }
@@ -110,19 +110,19 @@ public class DownloadingTileProvider implements TileProvider {
             }
     }
 
-    public BufferedImage getTile(String url) {
+    public BufferedImage getTile(String url, String cacheUrl) {
 
         // check local memory cache
-        Optional<BufferedImage> img = Optional.ofNullable(primaryTileCache.get(url));
+        Optional<BufferedImage> img = Optional.ofNullable(primaryTileCache.get(cacheUrl));
         if (img.isPresent()) {
             return img.get();
         }
 
         // now check configured local cache - if the image is there, and it's cache validity is not expired - return it
         if (secondaryCacheEnabled()) {
-                Optional<BufferedImage> image = Optional.ofNullable(mapViewer.getSecondaryTileCache().get(url));
-                if (image.isPresent() && !mapViewer.getSecondaryTileCache().keyExpired(url)) {
-                    primaryTileCache.put(url, image.get());
+                Optional<BufferedImage> image = Optional.ofNullable(mapViewer.getSecondaryTileCache().get(cacheUrl));
+                if (image.isPresent() && !mapViewer.getSecondaryTileCache().keyExpired(cacheUrl)) {
+                    primaryTileCache.put(cacheUrl, image.get());
                     return image.get();
                 }
 
@@ -132,7 +132,7 @@ public class DownloadingTileProvider implements TileProvider {
         // else submit tile for download from the web, but only if it's not already submitted
         if (!tilesLoading.contains(url)) {
             tilesLoading.add(url);
-            getExecutorService().submit(() -> download(url));
+            getExecutorService().submit(() -> download(url,cacheUrl));
         }
 
         return null;

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/HostPrefixAlternator.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/HostPrefixAlternator.java
@@ -1,0 +1,74 @@
+package net.wirelabs.jmaps.map.downloader;
+
+import lombok.Getter;
+
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
+
+public class HostPrefixAlternator {
+
+    private static final Pattern ALLOWED_ELEMENTS = Pattern.compile("^[a-zA-Z0-9_-]+(\\|[a-zA-Z0-9_-]+)*$");
+
+    private final String prefix;
+    private final String suffix;
+    @Getter
+    private final String cacheUrl;
+    private final String[] parts;
+    @Getter
+    private final List<String> all;
+
+
+    public HostPrefixAlternator(String url) {
+        String scheme = getScheme(url);
+        int schemeLen = scheme.length();
+
+        int open = url.indexOf('[', schemeLen);
+        int close = url.indexOf(']', schemeLen);
+
+        if (open == -1 && close == -1) {
+            this.prefix = url;
+            this.suffix = "";
+            this.cacheUrl = url;
+            this.parts = new String[]{url};
+            this.all = getAllHosts();
+            return;
+        }
+
+        if (open == -1 || close == -1) {
+            throw new IllegalArgumentException("Malformed URL: mismatched brackets");
+        }
+
+        if (open != schemeLen || close < open || url.indexOf('[', open + 1) != -1 || url.indexOf(']', close + 1) != -1) {
+            throw new IllegalArgumentException("Malformed URL");
+        }
+
+        String alternatingElements = url.substring(open + 1, close);
+        if (!ALLOWED_ELEMENTS.matcher(alternatingElements).matches()) {
+            throw new IllegalArgumentException("Invalid content inside [...]");
+        }
+        this.parts = alternatingElements.split("\\|");
+        this.prefix = url.substring(0, open);
+        this.suffix = url.substring(close + 1);
+        this.cacheUrl = prefix + (suffix.startsWith(".") ? suffix.substring(1) : suffix);
+        this.all = getAllHosts();
+    }
+
+    public String getDownloadUrl() {
+        if (parts.length == 1 && parts[0].equals(cacheUrl)) return cacheUrl;
+        return prefix + parts[ThreadLocalRandom.current().nextInt(parts.length)] + suffix;
+    }
+
+    private List<String> getAllHosts() {
+        if (parts.length == 1 && parts[0].equals(cacheUrl)) return List.of(cacheUrl);
+        return Arrays.stream(parts).map(p -> prefix + p + suffix).toList();
+    }
+
+    private static String getScheme(String url) {
+        if (url != null && url.startsWith("http://")) return "http://";
+        if (url != null && url.startsWith("https://")) return "https://";
+        throw new IllegalArgumentException("Invalid URL: " + url);
+    }
+}

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/TileProvider.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/TileProvider.java
@@ -3,5 +3,5 @@ package net.wirelabs.jmaps.map.downloader;
 import java.awt.image.*;
 
 public interface TileProvider {
-    BufferedImage getTile(String url);
+    BufferedImage getTile(String url, String cacheUrl);
 }

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/UrlSet.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/downloader/UrlSet.java
@@ -1,0 +1,3 @@
+package net.wirelabs.jmaps.map.downloader;
+
+public record UrlSet(String downloadUrl, String cacheUrl) {}

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/Layer.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/Layer.java
@@ -3,6 +3,8 @@ package net.wirelabs.jmaps.map.layer;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import net.wirelabs.jmaps.map.downloader.HostPrefixAlternator;
+import net.wirelabs.jmaps.map.downloader.UrlSet;
 import net.wirelabs.jmaps.map.geo.Coordinate;
 import net.wirelabs.jmaps.map.geo.ProjectionEngine;
 import net.wirelabs.jmaps.model.map.LayerDocument;
@@ -29,10 +31,12 @@ public abstract class Layer  {
     protected boolean disabled;
 
     private final ProjectionEngine projectionEngine = new ProjectionEngine();
+    private final HostPrefixAlternator hostPrefixAlternator;
 
     protected Layer(LayerDocument.Layer layerDefinition) {
         this.name = layerDefinition.getName();
         this.url = layerDefinition.getUrl();
+        this.hostPrefixAlternator = new HostPrefixAlternator(url);
         this.type = LayerType.valueOf(layerDefinition.getType());
         this.crs = layerDefinition.getCrs();
 
@@ -121,7 +125,7 @@ public abstract class Layer  {
      * @param zoom zoom level
      * @return string containing complete url ready to use
      */
-    public abstract String createTileUrl(int x, int y, int zoom);
+    public abstract UrlSet createTileUrl(int x, int y, int zoom);
     /**
      * Returns map size in tiles at given zoom
      * @param zoom zoom level

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/QuadLayer.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/QuadLayer.java
@@ -1,5 +1,6 @@
 package net.wirelabs.jmaps.map.layer;
 
+import net.wirelabs.jmaps.map.downloader.UrlSet;
 import net.wirelabs.jmaps.model.map.LayerDocument;
 
 public class QuadLayer extends XYZLayer {
@@ -13,13 +14,11 @@ public class QuadLayer extends XYZLayer {
 
 
     @Override
-    public String createTileUrl(int x, int y, int zoom) {
+    public UrlSet createTileUrl(int x, int y, int zoom) {
 
         final String quadKey = tileToQuadKey(x, y,  zoom);
-
-        return url.replace("{quad}", quadKey)
-                .replace("{quadchar}", String.valueOf(quadKey.charAt(quadKey.length() - 1)));
-
+        String origUrl =  url.replace("{quad}", quadKey).replace("{quadchar}", String.valueOf(quadKey.charAt(quadKey.length() - 1)));
+        return new UrlSet(origUrl,origUrl);
     }
 
     private String tileToQuadKey(final int x, final int y, final int zoom) {

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/WMTSLayer.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/WMTSLayer.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.opengis.ows.x11.DatasetDescriptionSummaryBaseType;
 import net.opengis.wmts.x10.CapabilitiesDocument;
 import net.opengis.wmts.x10.TileMatrixSetDocument;
+import net.wirelabs.jmaps.map.downloader.UrlSet;
 import net.wirelabs.jmaps.map.geo.GeoUtils;
 import net.wirelabs.jmaps.map.utils.UrlBuilder;
 import net.wirelabs.jmaps.model.map.LayerDocument;
@@ -124,8 +125,8 @@ public class WMTSLayer extends Layer {
 
     // todo: add style and format (recognize from capabilities)
     @Override
-    public String createTileUrl(int x, int y, int zoom) {
-        return urlBuilder.parse(url)
+    public UrlSet createTileUrl(int x, int y, int zoom) {
+        String originalUrl = urlBuilder.parse(url)
                 .addQueryParam("Service", "WMTS")
                 .addQueryParam("Request", "GetTile")
                 .addQueryParam("Layer", layerName)
@@ -137,6 +138,7 @@ public class WMTSLayer extends Layer {
                 .addQueryParam("TileRow", String.valueOf(y))
                 .addQueryParam("TileCol", String.valueOf(x))
                 .build();
+        return new UrlSet(originalUrl,originalUrl);
 
     }
 

--- a/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/XYZLayer.java
+++ b/jmaps-viewer/src/main/java/net/wirelabs/jmaps/map/layer/XYZLayer.java
@@ -1,5 +1,6 @@
 package net.wirelabs.jmaps.map.layer;
 
+import net.wirelabs.jmaps.map.downloader.UrlSet;
 import net.wirelabs.jmaps.model.map.LayerDocument;
 
 import java.awt.*;
@@ -34,15 +35,20 @@ public class XYZLayer extends Layer {
     }
 
     @Override
-    public String createTileUrl(int x, int y, int zoom) {
-        return url
-                .replace("{z}", String.valueOf(zoom))
-                .replace("{x}", String.valueOf(x))
-                .replace("{y}", String.valueOf(y));
+    public UrlSet createTileUrl(int x, int y, int zoom) {
+
+        String cacheUrl = substituteCoordinates(getHostPrefixAlternator().getCacheUrl(),x,y,zoom);
+        String downloadUrl = substituteCoordinates(getHostPrefixAlternator().getDownloadUrl(),x,y,zoom);
+        return new UrlSet(downloadUrl,cacheUrl);
 
     }
 
-
+    private String substituteCoordinates(String template, int x, int y, int zoom) {
+        return template
+                .replace("{z}", String.valueOf(zoom))
+                .replace("{x}", String.valueOf(x))
+                .replace("{y}", String.valueOf(y));
+    }
 
     @Override
     public double getMetersPerPixelAtZoom(int zoom) {

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/downloader/DownloadingTileProviderTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/downloader/DownloadingTileProviderTest.java
@@ -8,9 +8,7 @@ import net.wirelabs.jmaps.map.cache.memory.InMemoryLRUCache;
 import net.wirelabs.jmaps.map.utils.BaseTest;
 import org.apache.commons.io.FileUtils;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.verification.VerificationMode;
 
 import javax.imageio.ImageIO;
@@ -36,10 +34,10 @@ class DownloadingTileProviderTest extends BaseTest {
     private static final Duration SHORT_TIMEOUT_FOR_VALIDITY_TESTS = Duration.ofSeconds(2);
 
     private final DirectoryBasedCache secondaryCache = new DirectoryBasedCache(TEST_CACHE_DIR, Defaults.DEFAULT_CACHE_TIMEOUT);
-    private  MockHttpServer testTileServer;
 
-    private String tileUrl;
-    private String failTileUrl;
+    private static MockHttpServer testTileServer;
+    private static String tileUrl;
+    private static String failTileUrl;
 
     private final MapViewer mapViewer = new MapViewer();
     private final DownloadingTileProvider tileProvider = spy(new DownloadingTileProvider(mapViewer));
@@ -47,18 +45,22 @@ class DownloadingTileProviderTest extends BaseTest {
     private final DownloadingTileProvider tileProviderWithHttpClientMock = new DownloadingTileProvider(mapViewer, mockHttpClient);
     private InMemoryLRUCache primaryTileCache;
 
-    @BeforeEach
-    void before() throws IOException {
+    @BeforeAll
+    static void beforeAll() throws IOException {
         testTileServer = new MockHttpServer();
-        primaryTileCache = tileProvider.getPrimaryTileCache();
-        mapViewer.setSecondaryTileCache(secondaryCache);
         tileUrl = "http://localhost:" + testTileServer.getPort() + "/tile.png";
         failTileUrl = "http://localhost:" +testTileServer.getPort() +"/nonexisting";
+    }
+
+    @BeforeEach
+    void before() throws IOException {
+        primaryTileCache = tileProvider.getPrimaryTileCache();
+        mapViewer.setSecondaryTileCache(secondaryCache);
         FileUtils.deleteDirectory(TEST_CACHE_DIR.toFile());
     }
 
-    @AfterEach
-    void after() {
+    @AfterAll
+    static void after() {
         testTileServer.stop();
     }
 
@@ -76,7 +78,7 @@ class DownloadingTileProviderTest extends BaseTest {
     @Test
     void shouldNotDownloadNonExistingResource() {
         // download url that returns 404
-        tileProvider.download(failTileUrl);
+        tileProvider.download(failTileUrl,failTileUrl);
         // assert dowload attempted
         assertDownloadCalled(times(1));
         // assert tile not in caches
@@ -91,7 +93,7 @@ class DownloadingTileProviderTest extends BaseTest {
 
         primaryTileCache.put(tileUrl, ImageIO.read(TEST_TILE_FILE));
 
-        assertThat(tileProvider.getTile(tileUrl)).isNotNull();
+        assertThat(tileProvider.getTile(tileUrl,tileUrl)).isNotNull();
         assertDownloadCalled(never());
     }
 
@@ -113,7 +115,7 @@ class DownloadingTileProviderTest extends BaseTest {
         // put imagefile to secondary cache
         secondaryCache.put(tileUrl, ImageIO.read(TEST_TILE_FILE));
 
-        BufferedImage tile = tileProvider.getTile(tileUrl);
+        BufferedImage tile = tileProvider.getTile(tileUrl,tileUrl);
         // get from secondary should update primary too
         assertTileInPrimaryCache(tileUrl);
 
@@ -126,7 +128,7 @@ class DownloadingTileProviderTest extends BaseTest {
 
         // should not download file if it has not expired
         secondaryCache.put(tileUrl, ImageIO.read(TEST_TILE_FILE));
-        tileProvider.getTile(tileUrl);
+        tileProvider.getTile(tileUrl,tileUrl);
         assertDownloadCalled(never());
     }
 
@@ -160,18 +162,18 @@ class DownloadingTileProviderTest extends BaseTest {
     void shouldTestHttpClientExceptions() throws IOException, InterruptedException {
 
         doThrow(new IOException("Error")).when(mockHttpClient).send(any(),any());
-        tileProviderWithHttpClientMock.download(tileUrl);
+        tileProviderWithHttpClientMock.download(tileUrl,tileUrl);
         verifyLogged("Could not download " + tileUrl + " - IOException : Error");
 
         doThrow(new InterruptedException("Interrupted")).when(mockHttpClient).send(any(),any());
-        tileProviderWithHttpClientMock.download(tileUrl);
+        tileProviderWithHttpClientMock.download(tileUrl,tileUrl);
         verifyLogged("Download interrupted for " + tileUrl);
     }
 
     @Test
     void shouldCatchOOMException() throws IOException, InterruptedException {
         doThrow(new OutOfMemoryError()).when(mockHttpClient).send(any(),any());
-        tileProviderWithHttpClientMock.download(tileUrl);
+        tileProviderWithHttpClientMock.download(tileUrl,tileUrl);
         verifyLogged("DANG! Local memory cache run out of memory");
         verifyLogged("Pruning memory cache...");
     }
@@ -186,11 +188,11 @@ class DownloadingTileProviderTest extends BaseTest {
     }
 
     private void assertDownloadCalled(VerificationMode mode) {
-        verify(tileProvider, mode).download(anyString());
+        verify(tileProvider, mode).download(anyString(),anyString());
     }
 
     private void downloadTile() {
-        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(tileProvider.getTile(tileUrl)).isNotNull());
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(tileProvider.getTile(tileUrl,tileUrl)).isNotNull());
     }
 
     private void assertTileNotExpired() {

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/downloader/HostPrefixAlternatorTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/downloader/HostPrefixAlternatorTest.java
@@ -1,0 +1,154 @@
+package net.wirelabs.jmaps.map.downloader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@Slf4j
+class HostPrefixAlternatorTest {
+
+    HostPrefixAlternator alternator;
+
+
+    @Test
+    void shouldPassThru() {
+        // pass through - no alternation
+        alternator = new HostPrefixAlternator("http://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getAll()).containsOnly("http://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getCacheUrl()).isEqualTo("http://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+
+
+        alternator = new HostPrefixAlternator("https://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getAll()).containsOnly("https://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getCacheUrl()).isEqualTo("https://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+
+
+    }
+
+    @Test
+    void shouldExtractLegalMultiUrls() {
+        // classic one letter OSM style
+
+        alternator = new HostPrefixAlternator("http://[a|b|c].tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getAll()).containsOnly(
+                "http://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "http://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "http://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        );
+        assertThat(alternator.getCacheUrl()).isEqualTo("http://tile.openstreetmap.org/{z}/{x}/{y}.png");
+
+        // multiple letters, and https
+        alternator = new HostPrefixAlternator("https://[host1|host2|host3].tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getAll()).containsOnly(
+                "https://host1.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://host2.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://host3.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        );
+        assertThat(alternator.getCacheUrl()).isEqualTo("https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+
+
+    }
+
+    @Test
+    void shouldReturnRandomUrlFromMultihost() {
+        alternator = new HostPrefixAlternator("http://[a|b|c].tile.openstreetmap.org/{z}/{x}/{y}.png");
+        Awaitility.waitAtMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            String url1 = alternator.getDownloadUrl();
+            String url2 = alternator.getDownloadUrl();
+            assertThat(url1).isNotEqualTo(url2);
+        });
+    }
+
+    @Test
+    void shouldEctractOneElement() {
+        // one host alternation (legal but useless ;))
+        alternator = new HostPrefixAlternator("https://[a].tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getAll()).containsOnly("https://a.tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assertThat(alternator.getCacheUrl()).isEqualTo("https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+    }
+
+    @Test
+    void shouldThrowOnInvalidUrls() {
+        // TESTCASES:
+        // url does not contain http:// or https:// -> throw exception
+        // url contains other schema like ftp or ssh -> throw exception
+        // url is empty or null -> throw exception
+        // [a||b].host.com -> invalid, throw exception
+        // [a|].host.com -> invalid, throw exception
+        // [a,b,c].host.com -> invalid, throw exception
+        // multiple [...] sets -> invalid, throw exception
+        // mismatched brackets e.g "https://]host.com" or "https://[host.com") -> throw exception
+        // [...] does not appear immediately after the http:// or https://
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("[a|b].tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("http://[a||b].tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("http://[a| |b].tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("https://[a|].tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("http://[a,b,c].tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("https://[a|b,c].tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("http://[a|b|c].tile[a|b|c|d].openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("https://]].openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("https://][.tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("https://[.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("https://].openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("ftp://tile.openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("http://a.tile[a|b|c|d].openstreetmap.org/1/2/3.png");
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator(null);
+        });
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            alternator = new HostPrefixAlternator("");
+        });
+
+    }
+}

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/layer/QuadLayerTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/layer/QuadLayerTest.java
@@ -1,5 +1,6 @@
 package net.wirelabs.jmaps.map.layer;
 
+import net.wirelabs.jmaps.map.downloader.UrlSet;
 import net.wirelabs.jmaps.model.map.LayerDocument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,8 @@ class QuadLayerTest {
         layerDefinition.setUrl("http://quad-tile-service.net/tiles/{quad}.png");
         Layer quadLayer = new QuadLayer(layerDefinition);
 
-        String finalUrl = quadLayer.createTileUrl(11, 12, 14);
-        assertThat(finalUrl).isEqualTo("http://quad-tile-service.net/tiles/00000000003211.png");
+        UrlSet finalUrl = quadLayer.createTileUrl(11, 12, 14);
+        assertThat(finalUrl.downloadUrl()).isEqualTo("http://quad-tile-service.net/tiles/00000000003211.png");
     }
 
     @Test
@@ -35,8 +36,8 @@ class QuadLayerTest {
         layerDefinition.setUrl("http://host{quadchar}-quad-tile-service.net/tiles/{quad}.png");
         Layer quadLayer = new QuadLayer(layerDefinition);
 
-        String finalUrl = quadLayer.createTileUrl(18, 12, 12);
-        assertThat(finalUrl).isEqualTo("http://host0-quad-tile-service.net/tiles/000000012210.png");
+        UrlSet finalUrl = quadLayer.createTileUrl(18, 12, 12);
+        assertThat(finalUrl.downloadUrl()).isEqualTo("http://host0-quad-tile-service.net/tiles/000000012210.png");
 
     }
 

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/layer/WMTSLayerTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/layer/WMTSLayerTest.java
@@ -2,35 +2,32 @@ package net.wirelabs.jmaps.map.layer;
 
 import net.wirelabs.jmaps.MockHttpServer;
 import net.wirelabs.jmaps.model.map.LayerDocument;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WMTSLayerTest {
-    private String testUrl;
-    private LayerDocument.Layer wmtsLayerDefinition;
-    private MockHttpServer server;
 
-    @BeforeEach
-    void before() throws IOException {
+    private static String testUrl;
+    private static MockHttpServer server;
+    private static LayerDocument.Layer wmtsLayerDefinition;
 
-        // serve fake capabilities
-
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        // start mock capabilities server
         server = new MockHttpServer();
         testUrl = "http://localhost:"+ server.getPort() +"/valid1";
+        // serve fake layer definition
         wmtsLayerDefinition = LayerDocument.Layer.Factory.newInstance();
         wmtsLayerDefinition.setType(String.valueOf(LayerType.WMTS));
         wmtsLayerDefinition.setName("TestWmts");
         wmtsLayerDefinition.setUrl(testUrl);
-
     }
 
-    @AfterEach
-    void after() {
+    @AfterAll
+    static void afterAll() {
         server.stop();
     }
 
@@ -52,7 +49,7 @@ class WMTSLayerTest {
         assertThat(wmts.getZoomOffset()).isZero();
 
 
-        assertThat(wmts.createTileUrl(10, 11, 15)).isEqualTo(
+        assertThat(wmts.createTileUrl(10, 11, 15).downloadUrl()).isEqualTo(
                 testUrl + "?Service=WMTS" +
                         "&Request=GetTile" +
                         "&Layer=G2_MOBILE_500" +
@@ -86,7 +83,7 @@ class WMTSLayerTest {
         assertThat(wmts.isSwapAxis()).isTrue();
         assertThat(wmts.getCrs()).isEqualTo("EPSG:3187");
 
-        assertThat(wmts.createTileUrl(10, 11, 15)).isEqualTo(
+        assertThat(wmts.createTileUrl(10, 11, 15).downloadUrl()).isEqualTo(
                 testUrl + "?Service=WMTS" +
                         "&Request=GetTile" +
                         "&Layer=G2_MOBILE_500" +

--- a/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/layer/XYZLayerTest.java
+++ b/jmaps-viewer/src/test/java/net/wirelabs/jmaps/map/layer/XYZLayerTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import java.awt.*;
 import java.awt.geom.*;
+import java.time.Duration;
 import java.util.stream.Stream;
 
 import static net.wirelabs.jmaps.TestUtils.roundDouble;
@@ -21,7 +23,7 @@ class XYZLayerTest {
 
     @BeforeEach
     void before() {
-        xyzLayerDefinition =LayerDocument.Layer.Factory.newInstance();
+        xyzLayerDefinition = LayerDocument.Layer.Factory.newInstance();
         xyzLayerDefinition.setType(String.valueOf(LayerType.XYZ));
         xyzLayerDefinition.setName("TestXYZ");
         xyzLayerDefinition.setUrl("http://localhost/{z}/{x}/{y}.png");
@@ -30,7 +32,28 @@ class XYZLayerTest {
     @Test
     void shouldCreateCorrectUrl() {
         Layer xyz = new XYZLayer(xyzLayerDefinition);
-        assertThat(xyz.createTileUrl(4,5,12)).isEqualTo("http://localhost/12/4/5.png");
+        assertThat(xyz.createTileUrl(4, 5, 12).downloadUrl()).isEqualTo("http://localhost/12/4/5.png");
+    }
+
+    @Test
+    void shouldCreateCorectMultiHost() {
+        xyzLayerDefinition.setUrl("http://[a|b|c].localhost/12/4/5.png");
+        Layer xyz = new XYZLayer(xyzLayerDefinition);
+        assertThat(xyz.createTileUrl(4, 5, 12).downloadUrl()).matches("http://[abc].localhost/12/4/5\\.png");
+        assertThat(xyz.createTileUrl(4, 5, 12).cacheUrl()).isEqualTo("http://localhost/12/4/5.png");
+        // now check if hosts are really randomized
+        Layer layer = new XYZLayer(xyzLayerDefinition);
+        Awaitility.waitAtMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                    String url1 = layer.createTileUrl(4, 5, 12).downloadUrl();
+                    String url2 = layer.createTileUrl(4, 5, 12).downloadUrl();
+                    assertThat(url1).isNotEqualTo(url2);
+                }
+        );
+        xyzLayerDefinition.setUrl("http://[host1|host2|host3].localhost/12/4/5.png");
+        xyz = new XYZLayer(xyzLayerDefinition);
+        assertThat(xyz.createTileUrl(4, 5, 12).downloadUrl()).matches("http://(host1|host2|host3)\\.localhost/12/4/5\\.png");
+        assertThat(xyz.createTileUrl(4, 5, 12).cacheUrl()).isEqualTo("http://localhost/12/4/5.png");
+
     }
 
 
@@ -47,7 +70,6 @@ class XYZLayerTest {
         assertThat(roundDouble(pixelConvertedBackToLatLon.getLatitude(), 7)).isEqualTo(coord.getLatitude());
 
 
-
     }
 
     public static Stream<Arguments> providePoints() {
@@ -55,7 +77,7 @@ class XYZLayerTest {
         return Stream.of(
 
                 Arguments.of(new Coordinate(22.4900397, 51.2326363)),
-                Arguments.of(new Coordinate( -45.490, 43.213)),
+                Arguments.of(new Coordinate(-45.490, 43.213)),
                 Arguments.of(new Coordinate(39.091, -84.01)),
                 Arguments.of(new Coordinate(-39.091, -84.01))
         );
@@ -67,8 +89,8 @@ class XYZLayerTest {
     void getTopLeftCorner() {
         Layer xyz = new XYZLayer(xyzLayerDefinition);
         Point2D corner = xyz.getTopLeftCornerInMeters();
-        assertThat(corner.getX()).isEqualTo(-xyz.getProjectionEngine().getEquatorLength() /2 );
-        assertThat(corner.getY()).isEqualTo(xyz.getProjectionEngine().getPolarLength() /2 );
+        assertThat(corner.getX()).isEqualTo(-xyz.getProjectionEngine().getEquatorLength() / 2);
+        assertThat(corner.getY()).isEqualTo(xyz.getProjectionEngine().getPolarLength() / 2);
     }
 
     @Test
@@ -102,7 +124,7 @@ class XYZLayerTest {
 
 
     @Test
-    void shouldCreateXYZLayerWithNonDefaultValues()  {
+    void shouldCreateXYZLayerWithNonDefaultValues() {
 
         // xyz layer with custom params
 
@@ -128,5 +150,6 @@ class XYZLayerTest {
         assertThat(xyz.getZoomOffset()).isEqualTo(1);
 
     }
+
 
 }

--- a/jmaps-viewer/src/test/resources/map-creator/correct-multilayer.xml
+++ b/jmaps-viewer/src/test/resources/map-creator/correct-multilayer.xml
@@ -5,13 +5,13 @@
     <layer>
         <name>layer1</name>
         <type>XYZ</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
 
     <layer>
         <name>layer2</name>
         <type>XYZ</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
 
     <copyright>jmaps</copyright>

--- a/jmaps-viewer/src/test/resources/map-creator/correct-singlelayer.xml
+++ b/jmaps-viewer/src/test/resources/map-creator/correct-singlelayer.xml
@@ -4,7 +4,7 @@
     <layer>
         <name>Open Street Map</name>
         <type>XYZ</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
     <copyright>jmaps</copyright>
 </map>

--- a/jmaps-viewer/src/test/resources/map-creator/multilayer-different-crs.xml
+++ b/jmaps-viewer/src/test/resources/map-creator/multilayer-different-crs.xml
@@ -4,14 +4,14 @@
     <layer>
         <name>layer1</name>
         <type>QUAD</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
         <crs>EPSG:3857</crs>
     </layer>
 
     <layer>
         <name>layer2</name>
         <type>QUAD</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
         <crs>EPSG:3128</crs>
     </layer>
 

--- a/jmaps-viewer/src/test/resources/map-creator/multilayer-different-tilesize.xml
+++ b/jmaps-viewer/src/test/resources/map-creator/multilayer-different-tilesize.xml
@@ -4,14 +4,14 @@
     <layer>
         <name>layer1</name>
         <type>QUAD</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
         <tileSize>256</tileSize>
     </layer>
 
     <layer>
         <name>layer2</name>
         <type>QUAD</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
         <tileSize>128</tileSize>
     </layer>
 

--- a/jmaps-viewer/src/test/resources/map-creator/multilayer-disabled.xml
+++ b/jmaps-viewer/src/test/resources/map-creator/multilayer-disabled.xml
@@ -5,7 +5,7 @@
     <layer>
         <name>layer1</name>
         <type>XYZ</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
         <disabled>false</disabled>
         <swapAxis>true</swapAxis>
     </layer>
@@ -14,7 +14,7 @@
     <layer>
         <name>layer2</name>
         <type>XYZ</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
         <disabled>true</disabled>
     </layer>
 
@@ -22,7 +22,7 @@
     <layer>
         <name>default</name>
         <type>XYZ</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
 
     <copyright>jmaps</copyright>

--- a/jmaps-viewer/src/test/resources/map-creator/multilayer-samelayer.xml
+++ b/jmaps-viewer/src/test/resources/map-creator/multilayer-samelayer.xml
@@ -4,13 +4,13 @@
     <layer>
         <name>podklad</name>
         <type>QUAD</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
 
     <layer>
         <name>podklad</name>
         <type>QUAD</type>
-        <url>url</url>
+        <url>http://tile.openstreetmap.org/{z}/{x}/{y}.png</url>
     </layer>
 
     <copyright>jmaps</copyright>


### PR DESCRIPTION
Host prefix alternator - works only with slippy maps i.e host/x/y/z WMTS and QUAD do not support it so not implemented